### PR TITLE
Update openai_utils.py to allow for base url

### DIFF
--- a/llms/providers/openai_utils.py
+++ b/llms/providers/openai_utils.py
@@ -12,8 +12,8 @@ import aiolimiter
 import openai
 from openai import AsyncOpenAI, OpenAI
 
-client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
-aclient = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"], base_url=os.environ.get("OPENAI_BASE_URL"))
+aclient = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"], base_url=os.environ.get("OPENAI_BASE_URL"))
 from tqdm.asyncio import tqdm_asyncio
 
 


### PR DESCRIPTION
In the case where we are querying OpenAI through a proxy server, it can be helpful to set the base URL. This PR would add that ability (and not change behavior if it's not set.